### PR TITLE
use replaceIn param when setting query parameters

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "firefly-ui",
-  "version": "0.4.1",
+  "version": "0.4.2",
   "private": true,
   "dependencies": {
     "@emotion/react": "^11.4.1",

--- a/src/core/components/DataViewSwitch.tsx
+++ b/src/core/components/DataViewSwitch.tsx
@@ -36,7 +36,7 @@ export const DataViewSwitch: React.FC = () => {
     }
 
     // use view from state and update the url
-    setView(dataView);
+    setView(dataView, 'replaceIn');
   }, [view, setView, setDataView, dataView]);
 
   return (

--- a/src/core/components/DatePicker.tsx
+++ b/src/core/components/DatePicker.tsx
@@ -52,7 +52,7 @@ export const DatePicker: React.FC = () => {
     }
 
     // use time from state and update the url
-    setTime(createdFilter);
+    setTime(createdFilter, 'replaceIn');
   }, [time, setTime, setCreatedFilter, createdQueryOptions, createdFilter]);
 
   return (

--- a/src/modules/data/views/Data/Data.tsx
+++ b/src/modules/data/views/Data/Data.tsx
@@ -69,7 +69,7 @@ export const Data: () => JSX.Element = () => {
 
   useEffect(() => {
     //set query param state
-    setFilterQuery(activeFilters);
+    setFilterQuery(activeFilters, 'replaceIn');
     if (activeFilters.length === 0) {
       setFilterString('');
       return;

--- a/src/modules/data/views/Messages/Messages.tsx
+++ b/src/modules/data/views/Messages/Messages.tsx
@@ -71,7 +71,7 @@ export const Messages: () => JSX.Element = () => {
 
   useEffect(() => {
     //set query param state
-    setFilterQuery(activeFilters);
+    setFilterQuery(activeFilters, 'replaceIn');
     if (activeFilters.length === 0) {
       setFilterString('');
       return;

--- a/src/modules/data/views/Transactions/Transactions.tsx
+++ b/src/modules/data/views/Transactions/Transactions.tsx
@@ -72,7 +72,7 @@ export const Transactions: () => JSX.Element = () => {
 
   useEffect(() => {
     //set query param state
-    setFilterQuery(activeFilters);
+    setFilterQuery(activeFilters, 'replaceIn');
     if (activeFilters.length === 0) {
       setFilterString('');
       return;


### PR DESCRIPTION
By default, the `useQueryParam` hook pushes changes onto the history stack. When a page in the data explorer is visited without any query params, components like `DatePicker` and `DataViewSwitch` will detect the empty state and then set default parameters for `time` and `view`. This resulted in the browser's back button getting stuck between two states, one with query params and one without.

e.g. `http://localhost:3000/namespace/default/data/transactions?time=24hours` and `http://localhost:3000/namespace/default/data/transactions`

`useQueryParam` offers `replaceIn` and `replace` settings, which use `history.replace` instead of `history.push`. `replaceIn` is better than `replace` when using multiple query params, preventing them from overwriting each other's state