### PR TITLE
Data size format

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "dagre": "^0.8.5",
     "dayjs": "^1.11.1",
     "i18next": "^21.6.16",
+    "pretty-bytes": "^6.0.0",
     "react": "^17.0.2",
     "react-copy-to-clipboard": "^5.1.0",
     "react-dom": "^17.0.2",

--- a/src/pages/Off-Chain/views/Data.tsx
+++ b/src/pages/Off-Chain/views/Data.tsx
@@ -30,6 +30,7 @@ import { DateFilterContext } from '../../../contexts/DateFilterContext';
 import { FilterContext } from '../../../contexts/FilterContext';
 import { SlideContext } from '../../../contexts/SlideContext';
 import { SnackbarContext } from '../../../contexts/SnackbarContext';
+import prettyBytes from 'pretty-bytes';
 import {
   DataFilters,
   FF_Paths,
@@ -142,10 +143,7 @@ export const OffChainData: () => JSX.Element = () => {
       },
       {
         value: d.blob?.size ? (
-          <FFTableText
-            color="primary"
-            text={`${d.blob.size.toString()} ${t('bytes')}`}
-          />
+          <FFTableText color="primary" text={`${prettyBytes(d.blob.size)}`} />
         ) : (
           <FFTableText color="secondary" text={t('---')} />
         ),


### PR DESCRIPTION
Formats the size of blobs, making it more convenient when dealing with larger files.

Currently sizes are displayed in bytes:

<img width="1592" alt="Screen Shot 2022-04-28 at 2 39 04 PM" src="https://user-images.githubusercontent.com/41590273/165824789-09d36bb6-959a-4e55-8cc5-3d1996987f5e.png">

Sizes would be displayed using B, kB, MB, GB, TB,...

<img width="1597" alt="Screen Shot 2022-04-28 at 2 45 08 PM" src="https://user-images.githubusercontent.com/41590273/165824890-106fcb03-a0d8-4542-8229-2d798aa3c029.png">

