### PR TITLE
use selected namespace in API calls

### DIFF
--- a/src/components/Accordions/DataViewerAccordion.tsx
+++ b/src/components/Accordions/DataViewerAccordion.tsx
@@ -5,7 +5,8 @@ import {
   AccordionSummary,
   Grid,
 } from '@mui/material';
-import { useState } from 'react';
+import { useContext, useState } from 'react';
+import { ApplicationContext } from '../../contexts/ApplicationContext';
 import { IData } from '../../interfaces';
 import { DownloadButton } from '../Buttons/DownloadButton';
 import { DownloadJsonButton } from '../Buttons/DownloadJsonButton';
@@ -25,6 +26,7 @@ export const DataViewAccordion: React.FC<Props> = ({
   data,
 }) => {
   const [expanded, setExpanded] = useState<boolean>(isOpen);
+  const { selectedNamespace } = useContext(ApplicationContext);
 
   return (
     <Accordion
@@ -39,7 +41,12 @@ export const DataViewAccordion: React.FC<Props> = ({
           }
           rightContent={
             data.blob ? (
-              <DownloadButton isBlob url={data.id} filename={data.blob.name} />
+              <DownloadButton
+                isBlob
+                url={data.id}
+                namespace={selectedNamespace}
+                filename={data.blob.name}
+              />
             ) : (
               <DownloadJsonButton
                 jsonString={JSON.stringify(data.value)}

--- a/src/components/Accordions/MessageDataAccordion.tsx
+++ b/src/components/Accordions/MessageDataAccordion.tsx
@@ -71,6 +71,7 @@ export const MessageDataAccordion: React.FC<Props> = ({
                     isBlob
                     url={data.id}
                     filename={data.blob.name}
+                    namespace={selectedNamespace}
                   />
                 ) : (
                   <DownloadJsonButton

--- a/src/components/Buttons/DownloadButton.tsx
+++ b/src/components/Buttons/DownloadButton.tsx
@@ -6,15 +6,21 @@ interface Props {
   filename?: string;
   isBlob: boolean;
   url: string;
+  namespace: string;
 }
 
-export const DownloadButton: React.FC<Props> = ({ filename, isBlob, url }) => {
+export const DownloadButton: React.FC<Props> = ({
+  filename,
+  isBlob,
+  url,
+  namespace,
+}) => {
   return (
     <IconButton
       onClick={(e) => {
         e.stopPropagation();
         isBlob
-          ? downloadBlobFile(url, filename)
+          ? downloadBlobFile(url, namespace, filename)
           : downloadExternalFile(url, filename);
       }}
     >

--- a/src/components/Lists/ApiList.tsx
+++ b/src/components/Lists/ApiList.tsx
@@ -65,6 +65,7 @@ export const ApiList: React.FC<Props> = ({ api }) => {
                 filename={api.name}
                 url={api.urls.openapi}
                 isBlob={false}
+                namespace={selectedNamespace}
               />
               <FFCopyButton value={api.urls.openapi} />
             </>

--- a/src/components/Slides/IdentitySlide.tsx
+++ b/src/components/Slides/IdentitySlide.tsx
@@ -17,6 +17,7 @@
 import { Grid } from '@mui/material';
 import React, { useContext, useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
+import { ApplicationContext } from '../../contexts/ApplicationContext';
 import { SnackbarContext } from '../../contexts/SnackbarContext';
 import { FF_Paths, IIdentity } from '../../interfaces';
 import { DEFAULT_PADDING } from '../../theme';
@@ -37,6 +38,7 @@ export const IdentitySlide: React.FC<Props> = ({ did, open, onClose }) => {
   const { reportFetchError } = useContext(SnackbarContext);
   const { t } = useTranslation();
   const [identity, setIdentity] = useState<IIdentity>();
+  const { selectedNamespace } = useContext(ApplicationContext);
 
   const [isMounted, setIsMounted] = useState(false);
   useEffect(() => {
@@ -49,7 +51,9 @@ export const IdentitySlide: React.FC<Props> = ({ did, open, onClose }) => {
   useEffect(() => {
     isMounted &&
       fetchCatcher(
-        `${FF_Paths.apiPrefix}${FF_Paths.networkIdentitiesByDID(
+        `${
+          FF_Paths.nsPrefix
+        }/${selectedNamespace}/${FF_Paths.networkIdentitiesByDID(
           did
         )}?fetchverifiers`
       )

--- a/src/pages/Blockchain/views/Apis.tsx
+++ b/src/pages/Blockchain/views/Apis.tsx
@@ -155,6 +155,7 @@ export const BlockchainApis: () => JSX.Element = () => {
             filename={api.name}
             url={api.urls.openapi}
             isBlob={false}
+            namespace={selectedNamespace}
           />
         ),
       },

--- a/src/pages/Blockchain/views/Dashboard.tsx
+++ b/src/pages/Blockchain/views/Dashboard.tsx
@@ -247,6 +247,7 @@ export const BlockchainDashboard: () => JSX.Element = () => {
             filename={api.name}
             url={api.urls.openapi}
             isBlob={false}
+            namespace={selectedNamespace}
           />
         ),
       },

--- a/src/pages/Off-Chain/views/Dashboard.tsx
+++ b/src/pages/Off-Chain/views/Dashboard.tsx
@@ -231,7 +231,12 @@ export const OffChainDashboard: () => JSX.Element = () => {
       },
       {
         value: data.blob ? (
-          <DownloadButton isBlob url={data.id} filename={data.blob?.name} />
+          <DownloadButton
+            isBlob
+            url={data.id}
+            filename={data.blob?.name}
+            namespace={selectedNamespace}
+          />
         ) : (
           <FFTableText color="secondary" text={t('noBlobInData')} />
         ),

--- a/src/pages/Off-Chain/views/Data.tsx
+++ b/src/pages/Off-Chain/views/Data.tsx
@@ -159,7 +159,12 @@ export const OffChainData: () => JSX.Element = () => {
       },
       {
         value: d.blob && (
-          <DownloadButton isBlob url={d.id} filename={d.blob?.name} />
+          <DownloadButton
+            isBlob
+            url={d.id}
+            filename={d.blob?.name}
+            namespace={selectedNamespace}
+          />
         ),
       },
     ],

--- a/src/utils/files.ts
+++ b/src/utils/files.ts
@@ -1,8 +1,12 @@
 import { fetchWithCredentials } from './fetches';
 
-export const downloadBlobFile = async (id: string, filename?: string) => {
+export const downloadBlobFile = async (
+  id: string,
+  namespace: string,
+  filename?: string
+) => {
   const file = await fetchWithCredentials(
-    `/api/v1/namespaces/default/data/${id}/blob`
+    `/api/v1/namespaces/${namespace}/data/${id}/blob`
   );
   const blob = await file.blob();
   const href = await URL.createObjectURL(blob);


### PR DESCRIPTION
Updating the requests for downloading blobs & identity to utilize the current selected namespace, instead of always using the default namespace. 

closes #193 