### PR TITLE
update network map to better fit large networks

### DIFF
--- a/src/components/NetworkMap/NetworkMap.tsx
+++ b/src/components/NetworkMap/NetworkMap.tsx
@@ -39,9 +39,9 @@ interface Props {
 const NODE_STRING_DELIM = '||';
 const SIZE_MAP = {
   small: {
-    node: 40,
-    org: 75,
-    distance: 100,
+    node: 24,
+    org: 36,
+    distance: 60,
   },
   medium: {
     node: 90,
@@ -223,6 +223,9 @@ export const NetworkMap: React.FC<Props> = ({ size }) => {
       case 5:
         return size === 'small' ? 17 : 60;
       default:
+        if (numOrgs > 10) {
+          return 3.2;
+        }
         return 50;
     }
   };

--- a/src/pages/Network/views/Dashboard.tsx
+++ b/src/pages/Network/views/Dashboard.tsx
@@ -39,7 +39,7 @@ export const NetworkMapDashboard: () => JSX.Element = () => {
         noDateFilter
       ></Header>
       <FFPageLayout height="85vh">
-        {isMounted && <NetworkMap size="large" />}
+        {isMounted && <NetworkMap size="small" />}
       </FFPageLayout>
     </>
   );


### PR DESCRIPTION
Make the network map default `small` and reduce sizing so larger networks will show better

![Screen Shot 2022-10-18 at 2 46 32 PM](https://user-images.githubusercontent.com/10987380/196518487-4fc677f7-0e53-41f3-8b23-33ef14d1bda2.png)
![Screen Shot 2022-10-18 at 2 46 24 PM](https://user-images.githubusercontent.com/10987380/196518491-9fabdb71-b0a5-4bb6-b5bf-dbd65ab212eb.png)
![Screen Shot 2022-10-18 at 2 45 37 PM](https://user-images.githubusercontent.com/10987380/196518493-be022224-98a9-4df1-bcd7-1ad6c55fc034.png)
![Screen Shot 2022-10-18 at 2 45 22 PM](https://user-images.githubusercontent.com/10987380/196518498-c4904f96-e40a-472d-b00c-f7e102f03191.png)
