### PR TITLE
add `uri` to token transfers slide

### DIFF
--- a/src/components/Lists/TransferList.tsx
+++ b/src/components/Lists/TransferList.tsx
@@ -110,6 +110,11 @@ export const TransferList: React.FC<Props> = ({
           button: <FFCopyButton value={transfer.tokenIndex ?? ''} />,
         },
         {
+          label: transfer.uri ? t('uri') : '',
+          value: <FFListText color="primary" text={transfer.uri ?? ''} />,
+          button: <FFCopyButton value={transfer.uri ?? ''} />,
+        },
+        {
           label: t('messageID'),
           value: transfer.message ? (
             <FFListText color="primary" text={transfer.message} />


### PR DESCRIPTION
The token `uri` will be displayed on the transfers slide, if it exists. I did not add it to the table view, but happy to do something similar to how it is displayed for balances. 

closes #201 


![Screen Shot 2022-11-17 at 10 16 45 AM](https://user-images.githubusercontent.com/10987380/202486229-152ac0cd-4e3e-4e87-b5a1-665e874280c3.png)
![Screen Shot 2022-11-17 at 10 16 34 AM](https://user-images.githubusercontent.com/10987380/202486238-47412866-b1b6-445a-98e0-9b3b2d6a37d1.png)
