### PR TITLE
Misc UI cleanup around transactions and events

### DIFF
--- a/src/components/Cards/EventCards/EventCardWrapper.tsx
+++ b/src/components/Cards/EventCards/EventCardWrapper.tsx
@@ -15,16 +15,22 @@ interface Props {
   link?: string;
   linkState?: any;
   onHandleViewEvent?: any;
+  lookupTxNames?: boolean;
 }
 
-export const EventCardWrapper = ({ event, onHandleViewEvent, link }: Props) => {
+export const EventCardWrapper = ({
+  event,
+  onHandleViewEvent,
+  link,
+  lookupTxNames,
+}: Props) => {
   const { t } = useTranslation();
 
   return (
     <BaseCard
       onClick={() => onHandleViewEvent(event)}
       title={
-        event.transaction
+        lookupTxNames && event.transaction
           ? t(
               FF_TX_CATEGORY_MAP[event.transaction?.type]?.nicename ??
                 event.transaction?.type

--- a/src/pages/Activity/views/Timeline.tsx
+++ b/src/pages/Activity/views/Timeline.tsx
@@ -137,6 +137,7 @@ export const ActivityTimeline: () => JSX.Element = () => {
         key: idx,
         item: (
           <EventCardWrapper
+            lookupTxNames
             onHandleViewEvent={(event: IEvent) => {
               if (event.transaction) {
                 setViewTx(event.transaction);

--- a/src/pages/Activity/views/TransactionDetails.tsx
+++ b/src/pages/Activity/views/TransactionDetails.tsx
@@ -154,7 +154,7 @@ export const TransactionDetails: () => JSX.Element = () => {
   ];
 
   const operationsCard: IFireFlyCard = {
-    headerText: t('blockchainOperations'),
+    headerText: t('operations'),
     clickPath:
       tx?.id &&
       FF_NAV_PATHS.activityOpPathWithTxFilter(selectedNamespace, tx.id),

--- a/src/pages/Home/views/Dashboard.tsx
+++ b/src/pages/Home/views/Dashboard.tsx
@@ -387,6 +387,7 @@ export const HomeDashboard: () => JSX.Element = () => {
             recentEventTxs.map((event) => (
               <React.Fragment key={event.id}>
                 <EventCardWrapper
+                  lookupTxNames
                   onHandleViewEvent={(event: IEvent) => {
                     setViewTx(event.transaction);
                     setSlideSearchParam(event?.tx ?? null);

--- a/src/pages/Home/views/Dashboard.tsx
+++ b/src/pages/Home/views/Dashboard.tsx
@@ -475,7 +475,10 @@ export const HomeDashboard: () => JSX.Element = () => {
 
             const enrichedRecentEvents: IEvent[] = [];
             for (const event of recentEvents) {
-              if (event.type === FF_EVENTS.TOKEN_TRANSFER_CONFIRMED) {
+              if (
+                event.type === FF_EVENTS.TOKEN_TRANSFER_CONFIRMED &&
+                event.tokenTransfer
+              ) {
                 const transferWithPool = await fetchPoolObjectFromTransfer(
                   event.tokenTransfer,
                   selectedNamespace,

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -44,7 +44,6 @@
   "blockchainInvokeFailed": "Blockchain Invoke Failed",
   "blockchainInvokeSucceeded": "Blockchain Invoke Succeeded",
   "blockchainNetworkAction": "Blockchain Network Action",
-  "blockchainOperations": "Blockchain Operations",
   "blockchainTransaction": "Blockchain Transaction",
   "blockchainTransactions": "Blockchain Transactions",
   "blockNumber": "Block Number",


### PR DESCRIPTION
* Only replace "Transaction Submitted" with transaction name on split views
* Replace "Blockchain Operations" header with just "Operations"
* Add a missing "undefined" check for token transfer events