### PR TITLE
Large nums as strings

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -21,6 +21,7 @@
         "dagre": "^0.8.5",
         "dayjs": "^1.11.1",
         "i18next": "^21.6.16",
+        "lossless-json": "^4.0.2",
         "pretty-bytes": "^6.0.0",
         "react": "^17.0.2",
         "react-copy-to-clipboard": "^5.1.0",
@@ -38,6 +39,7 @@
       },
       "devDependencies": {
         "@types/jest": "^27.4.1",
+        "@types/lossless-json": "^1.0.4",
         "@types/node": "^17.0.25",
         "@types/react": "^17.0.43",
         "@types/react-copy-to-clipboard": "^5.0.2",
@@ -4135,6 +4137,12 @@
       "version": "0.0.29",
       "resolved": "https://registry.npmjs.org/@types/json5/-/json5-0.0.29.tgz",
       "integrity": "sha1-7ihweulOEdK4J7y+UnC86n8+ce4="
+    },
+    "node_modules/@types/lossless-json": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@types/lossless-json/-/lossless-json-1.0.4.tgz",
+      "integrity": "sha512-eHhzo0p2p9On3cTr5X0Q0XsOjJxkqYzQi5Le5ObSiJjnLlGpDQvTcQEXknCkvKOFLBLa8ny4dgJKr0ADRV8yig==",
+      "dev": true
     },
     "node_modules/@types/mime": {
       "version": "1.3.2",
@@ -11957,6 +11965,11 @@
       "bin": {
         "loose-envify": "cli.js"
       }
+    },
+    "node_modules/lossless-json": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/lossless-json/-/lossless-json-4.0.2.tgz",
+      "integrity": "sha512-+z0EaLi2UcWi8MZRxA5iTb6m4Ys4E80uftGY+yG5KNFJb5EceQXOhdW/pWJZ8m97s26u7yZZAYMcKWNztSZssA=="
     },
     "node_modules/lower-case": {
       "version": "2.0.2",
@@ -20277,6 +20290,12 @@
       "resolved": "https://registry.npmjs.org/@types/json5/-/json5-0.0.29.tgz",
       "integrity": "sha1-7ihweulOEdK4J7y+UnC86n8+ce4="
     },
+    "@types/lossless-json": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@types/lossless-json/-/lossless-json-1.0.4.tgz",
+      "integrity": "sha512-eHhzo0p2p9On3cTr5X0Q0XsOjJxkqYzQi5Le5ObSiJjnLlGpDQvTcQEXknCkvKOFLBLa8ny4dgJKr0ADRV8yig==",
+      "dev": true
+    },
     "@types/mime": {
       "version": "1.3.2",
       "resolved": "https://registry.npmjs.org/@types/mime/-/mime-1.3.2.tgz",
@@ -26053,6 +26072,11 @@
       "requires": {
         "js-tokens": "^3.0.0 || ^4.0.0"
       }
+    },
+    "lossless-json": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/lossless-json/-/lossless-json-4.0.2.tgz",
+      "integrity": "sha512-+z0EaLi2UcWi8MZRxA5iTb6m4Ys4E80uftGY+yG5KNFJb5EceQXOhdW/pWJZ8m97s26u7yZZAYMcKWNztSZssA=="
     },
     "lower-case": {
       "version": "2.0.2",

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "dagre": "^0.8.5",
     "dayjs": "^1.11.1",
     "i18next": "^21.6.16",
+    "lossless-json": "^4.0.2",
     "pretty-bytes": "^6.0.0",
     "react": "^17.0.2",
     "react-copy-to-clipboard": "^5.1.0",
@@ -60,6 +61,7 @@
   },
   "devDependencies": {
     "@types/jest": "^27.4.1",
+    "@types/lossless-json": "^1.0.4",
     "@types/node": "^17.0.25",
     "@types/react": "^17.0.43",
     "@types/react-copy-to-clipboard": "^5.0.2",

--- a/src/utils/fetches.ts
+++ b/src/utils/fetches.ts
@@ -32,13 +32,7 @@ export const fetchCatcher = async (resource: string): Promise<any> => {
   const response = await fetchWithCredentials(resource);
   if (!response.ok) {
   } else {
-    const responseText = await response.text();
-    const responseJSONLargeNumbersStringified = parse(
-      responseText,
-      null,
-      parseLargeNumbersAsStrings
-    );
-    return responseJSONLargeNumbersStringified;
+    return await parse(await response.text(), null, parseLargeNumbersAsStrings);
   }
 };
 


### PR DESCRIPTION
Relates to https://github.com/hyperledger/firefly/issues/1568

With large JSON numbers supported in FF (see https://github.com/hyperledger/firefly/pull/1569 and https://github.com/hyperledger/firefly/pull/1581) the FireFly UI received large numbers correctly but then lost precision when rendering them.

For example the following `Data` viewer:

![image](https://github.com/user-attachments/assets/29a4fbb2-dc70-4884-b5b3-ccd1d28906c7)

which was rendered from the following JSON payload from FF:

```
...
  "datatype": {
    "name": "mattdata",
    "version": "1.0.0"
  },
  "value": {
    "id": 1000000000000000001
  }
...
```

This PR uses the MIT-licenses package `lossless-json` to replace the `JSON.parse` step in all `fetch(...)` calls. It stringifies numbers that are too large to be represented as a Javascript `number` e.g.

![image](https://github.com/user-attachments/assets/1b5ea040-5835-42f0-9923-b1718313a1ba)

which is from the same JSON payload as above.

The parser leaves all other data untouched (i.e. it returns the same JSON as `JSON.parse` except for the case where a number is determined to be a number that cannot be safely represented as a Javascript `number`).

Here is an example of a small number, which is represented exactly as it would be before this PR:

![image](https://github.com/user-attachments/assets/1e5fe295-9e7a-4916-bbaa-9617511056f6)

Here is an example of a string, also represented exactly as it would be before this PR:

![image](https://github.com/user-attachments/assets/d6a43779-6d95-4072-a7ec-bc27a15dd419)

